### PR TITLE
require symfony/framework-bundle instead of symfony/symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "homepage": "https://github.com/gpenverne"
     }],
     "require": {
-        "symfony/symfony": ">=2.8",
+        "symfony/framework-bundle": ">=2.8",
         "cloudflare/sdk": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hello,

I was just starting to upgrade some projects to use flex and ran into problems with this bundle requirements as the flex skeleton project conflicts with symfony/symfony requirements. The issue case is easy to reproduce with the following:

php7.2 /usr/bin/composer create-project symfony/skeleton testProject 3.4.99
php7.2 /usr/bin/composer require gpenverne/cloudflare-bundle

I'm not sure whether this change works on 2.8 but on 3.4 and 4.4 it solved my composer install/update issues. As you can see, I haven't been using github so please feel free to give some advise/instructions if there something that I can help with in this regard.